### PR TITLE
Curve the arrows.

### DIFF
--- a/graph_viewer/script.js
+++ b/graph_viewer/script.js
@@ -514,12 +514,12 @@ function drawArrow(fromElem, toElem, svgContainer, dashed, dotted) {
       svgContainer.appendChild(defs);
     }
   
-    // Create the line (arrow)
-    const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
-    line.setAttribute('x1', fromX);
-    line.setAttribute('y1', fromY);
-    line.setAttribute('x2', toX);
-    line.setAttribute('y2', toY);
+    // Create the bezier curve (arrow)
+    const line = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    const mid_x = (fromX + toX) * 0.5 + (fromY - toY) * 0.1;
+    const mid_y = (fromY + toY) * 0.5 - (fromX - toX) * 0.1;
+    line.setAttribute('d', `M${fromX} ${fromY} Q${mid_x} ${mid_y} ${toX} ${toY}`);
+    line.setAttribute('fill', 'none');
     line.setAttribute('stroke', color); // Arrow color
     if (dashed) {
         line.setAttribute('stroke-dasharray', '4');


### PR DESCRIPTION
When arrows are slightly curved in a particular direction, it is easier to see their direction and distinguish from the other arrow.

Before:
![image](https://github.com/user-attachments/assets/e23f85bb-fcb3-4402-9320-aecea43d166e)


After:
![image](https://github.com/user-attachments/assets/c69964dc-ea50-4716-89b9-ef9c54e5cc9b)
